### PR TITLE
Add themes like Windows 7, MacOS 9

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -35,6 +35,26 @@ a {
   --taskbar-height: 32px;
 }
 
+.theme-windows7 {
+  --taskbar-height: 40px;
+  --taskbar-bg-color: #1c1c1c;
+  --taskbar-text-color: #ffffff;
+  --window-bg-color: #f0f0f0;
+  --window-border-color: #a0a0a0;
+  --button-bg-color: #e0e0e0;
+  --button-border-color: #707070;
+  --button-text-color: #000000;
+}
+
+.theme-macos9 {
+  --taskbar-height: 22px;
+  --window-border-color: #c0c0c0;
+  --window-background-color: #e0e0e0;
+  --button-background-color: #d0d0d0;
+  --button-border-color: #808080;
+  --button-text-color: #000000;
+}
+
 ::-webkit-scrollbar-button:vertical:start:increment,
 ::-webkit-scrollbar-button:vertical:end:decrement,
 ::-webkit-scrollbar-button:horizontal:start:increment,

--- a/app/themes/macos9.css
+++ b/app/themes/macos9.css
@@ -1,0 +1,41 @@
+/* MacOS 9 Theme */
+
+:root {
+  --taskbar-height: 22px;
+  --window-border-color: #c0c0c0;
+  --window-background-color: #e0e0e0;
+  --button-background-color: #d0d0d0;
+  --button-border-color: #808080;
+  --button-text-color: #000000;
+}
+
+body {
+  font-family: "Chicago", Arial, sans-serif;
+  background-color: #808080;
+}
+
+.taskbar {
+  background-color: #c0c0c0;
+  border-top: 1px solid #ffffff;
+  border-left: 1px solid #ffffff;
+  border-right: 1px solid #000000;
+  border-bottom: 1px solid #000000;
+  height: var(--taskbar-height);
+}
+
+.window {
+  background-color: var(--window-background-color);
+  border: 2px solid var(--window-border-color);
+  box-shadow: 1px 1px 0 0 #ffffff, -1px -1px 0 0 #000000;
+}
+
+.button {
+  background-color: var(--button-background-color);
+  border: 1px solid var(--button-border-color);
+  color: var(--button-text-color);
+  box-shadow: 1px 1px 0 0 #ffffff, -1px -1px 0 0 #000000;
+}
+
+.button:active {
+  box-shadow: inset 1px 1px 0 0 #000000, inset -1px -1px 0 0 #ffffff;
+}

--- a/app/themes/windows7.css
+++ b/app/themes/windows7.css
@@ -1,0 +1,29 @@
+/* Windows 7 Theme Styles */
+
+:root {
+  --taskbar-height: 40px;
+  --taskbar-bg-color: #1c1c1c;
+  --taskbar-text-color: #ffffff;
+  --window-bg-color: #f0f0f0;
+  --window-border-color: #a0a0a0;
+  --button-bg-color: #e0e0e0;
+  --button-border-color: #707070;
+  --button-text-color: #000000;
+}
+
+.taskbar {
+  background-color: var(--taskbar-bg-color);
+  color: var(--taskbar-text-color);
+  height: var(--taskbar-height);
+}
+
+.window {
+  background-color: var(--window-bg-color);
+  border: 1px solid var(--window-border-color);
+}
+
+.button {
+  background-color: var(--button-bg-color);
+  border: 1px solid var(--button-border-color);
+  color: var(--button-text-color);
+}

--- a/components/MenuBar.tsx
+++ b/components/MenuBar.tsx
@@ -16,6 +16,13 @@ type Option = {
 
 export function MenuBar({ options }: { options: Options }) {
   const [openMenuLabel, setOpenMenuLabel] = useState<string | null>(null);
+  const [selectedTheme, setSelectedTheme] = useState("default");
+
+  const handleThemeChange = (theme: string) => {
+    setSelectedTheme(theme);
+    document.documentElement.className = theme;
+  };
+
   if (!options.length) return null;
 
   return (
@@ -28,6 +35,18 @@ export function MenuBar({ options }: { options: Options }) {
           setOpenMenuLabel={setOpenMenuLabel}
         />
       ))}
+      <div className={styles.menuBarButtonContainer}>
+        <label htmlFor="theme-select">Theme:</label>
+        <select
+          id="theme-select"
+          value={selectedTheme}
+          onChange={(e) => handleThemeChange(e.target.value)}
+        >
+          <option value="default">Default</option>
+          <option value="windows7">Windows 7</option>
+          <option value="macos9">MacOS 9</option>
+        </select>
+      </div>
     </div>
   );
 }

--- a/components/OS.tsx
+++ b/components/OS.tsx
@@ -3,7 +3,7 @@
 import styles from "./OS.module.css";
 import cx from "classnames";
 import { getDefaultStore, useAtom, useAtomValue, useSetAtom } from "jotai";
-import { useEffect } from "react";
+import { useEffect, useState } from "react"; // P2faf
 import { focusedWindowAtom } from "@/state/focusedWindow";
 import { windowsListAtom } from "@/state/windowsList";
 import { windowAtomFamily } from "@/state/window";
@@ -18,6 +18,8 @@ import Image from "next/image";
 import { initState } from "@/lib/initState";
 import { WIDTH } from "./programs/Welcome";
 import { fsManagerAtom } from "@/state/fsManager";
+import "@/app/themes/windows7.css"; // Pc748
+import "@/app/themes/macos9.css"; // Pc748
 
 export function OS() {
   // Temp fix lol
@@ -25,6 +27,7 @@ export function OS() {
   const [windows] = useAtom(windowsListAtom);
   const setFocusedWindow = useSetAtom(focusedWindowAtom);
   const registry = useAtomValue(registryAtom);
+  const [selectedTheme, setSelectedTheme] = useState("default"); // P2faf
 
   const publicDesktopUrl = registry[DESKTOP_URL_KEY] ?? "/bg.jpg";
 
@@ -65,6 +68,7 @@ export function OS() {
         backgroundPosition: "center",
         overflow: "hidden",
       }}
+      className={selectedTheme} // P07b7
       onContextMenu={(e) => {
         e.preventDefault();
       }}
@@ -74,13 +78,13 @@ export function OS() {
         <Window key={id} id={id} />
       ))}
 
-      <TaskBar />
+      <TaskBar selectedTheme={selectedTheme} setSelectedTheme={setSelectedTheme} /> {/* P07b7 */}
       <ContextMenu />
     </div>
   );
 }
 
-function TaskBar() {
+function TaskBar({ selectedTheme, setSelectedTheme }) { // P07b7
   const windows = useAtomValue(windowsListAtom);
   const [startMenuOpen, setStartMenuOpen] = useAtom(startMenuOpenAtom);
   return (
@@ -94,7 +98,7 @@ function TaskBar() {
       >
         Start
       </button>
-      {startMenuOpen && <StartMenu />}
+      {startMenuOpen && <StartMenu selectedTheme={selectedTheme} setSelectedTheme={setSelectedTheme} />} {/* P07b7 */}
       <div className={styles.divider}></div>
       {windows.map((id) => (
         <WindowTaskBarItem key={id} id={id} />
@@ -103,7 +107,7 @@ function TaskBar() {
   );
 }
 
-function StartMenu() {
+function StartMenu({ selectedTheme, setSelectedTheme }) { // P07b7
   const { logout } = useActions();
 
   const entries: { label: string; cb: () => void }[] = [
@@ -178,6 +182,18 @@ function StartMenu() {
           Logout
         </button>
       </form>
+      <div>
+        <label htmlFor="theme-select">Theme:</label>
+        <select
+          id="theme-select"
+          value={selectedTheme}
+          onChange={(e) => setSelectedTheme(e.target.value)}
+        >
+          <option value="default">Default</option>
+          <option value="windows7">Windows 7</option>
+          <option value="macos9">MacOS 9</option>
+        </select>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Add themes for Windows 7 and MacOS 9.

* **New CSS Files**:
  - Add `app/themes/windows7.css` with styles for Windows 7 theme.
  - Add `app/themes/macos9.css` with styles for MacOS 9 theme.
* **Theme Switching Logic**:
  - Modify `components/OS.tsx` to import new theme CSS files and add state for selected theme.
  - Implement theme switching logic in `components/OS.tsx` and `TaskBar` component.
  - Add theme selection options in the `StartMenu` component.
* **MenuBar Component**:
  - Modify `components/MenuBar.tsx` to include theme selection options.
  - Implement event handlers for theme change in `MenuBar` component.
* **Global Styles**:
  - Update `app/globals.css` to include base styles for theme support.
  - Add CSS variables for Windows 7 and MacOS 9 themes in `app/globals.css`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/SawyerHood/windows9x?shareId=b9afe225-90ce-4415-bedf-69723c072902).